### PR TITLE
Add connection pool size configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,6 @@ The proxy can be launched:
 - several times, clients will be automaticaly balanced between instances
 - with uvloop module to get an extra speed boost
 - with runtime statistics exported to [Prometheus](https://prometheus.io/)
+- set `MAX_CONNS_IN_POOL` to control how many Telegram connections are kept in
+  the pool. Reducing it (e.g. setting to `1`) avoids excessive reconnect
+  attempts when there are few users.

--- a/config.py
+++ b/config.py
@@ -25,3 +25,7 @@ MODES = {
 
 # Tag for advertising, obtainable from @MTProxybot
 # AD_TAG = "3c09c680b76ee91a4c25ad51f742267d"
+
+# maximum count of Telegram connections in the pool. Reducing this value may
+# help when running the proxy for a small number of users.
+MAX_CONNS_IN_POOL = 64

--- a/mtprotoproxy.py
+++ b/mtprotoproxy.py
@@ -265,6 +265,9 @@ def init_config():
     # telegram servers connect timeout in seconds
     conf_dict.setdefault("TG_CONNECT_TIMEOUT", 10)
 
+    # the number of telegram connections kept in a pool
+    conf_dict.setdefault("MAX_CONNS_IN_POOL", 64)
+
     # listen address for IPv4
     conf_dict.setdefault("LISTEN_ADDR_IPV4", "0.0.0.0")
 
@@ -294,6 +297,7 @@ def init_config():
 
     # allow access to config by attributes
     config = type("config", (dict,), conf_dict)(conf_dict)
+    TgConnectionPool.MAX_CONNS_IN_POOL = config.MAX_CONNS_IN_POOL
 
 
 def apply_upstream_proxy_settings():


### PR DESCRIPTION
## Summary
- expose `MAX_CONNS_IN_POOL` option in `config.py`
- make `init_config()` honor `MAX_CONNS_IN_POOL` and assign its value to the pool
- document the option in README

## Testing
- `python3 -m py_compile mtprotoproxy.py config.py`

------
https://chatgpt.com/codex/tasks/task_b_685380bdbb008333a5b3921518942d2a