### PR TITLE
Add datacenter info update task

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,4 @@ The proxy can be launched:
 - several times, clients will be automaticaly balanced between instances
 - with uvloop module to get an extra speed boost
 - with runtime statistics exported to [Prometheus](https://prometheus.io/)
+- datacenter addresses refresh automatically (tweak with `DC_INFO_UPDATE_PERIOD`)

--- a/config.py
+++ b/config.py
@@ -25,3 +25,6 @@ MODES = {
 
 # Tag for advertising, obtainable from @MTProxybot
 # AD_TAG = "3c09c680b76ee91a4c25ad51f742267d"
+
+# Interval for datacenter info refresh in seconds
+# DC_INFO_UPDATE_PERIOD = 24*60*60

--- a/mtprotoproxy.py
+++ b/mtprotoproxy.py
@@ -240,6 +240,9 @@ def init_config():
     # delay in seconds between middle proxy info updates
     conf_dict.setdefault("PROXY_INFO_UPDATE_PERIOD", 24*60*60)
 
+    # delay in seconds between datacenter info updates
+    conf_dict.setdefault("DC_INFO_UPDATE_PERIOD", 24*60*60)
+
     # delay in seconds between time getting, zero means disabled
     conf_dict.setdefault("GET_TIME_PERIOD", 10*60)
 
@@ -2024,6 +2027,33 @@ async def clear_ip_resolving_cache():
         await asyncio.sleep(myrandom.randrange(min_sleep, max_sleep))
 
 
+async def update_datacenter_info():
+    DC_INFO_ADDR_V4 = "https://core.telegram.org/getDcV4"
+    DC_INFO_ADDR_V6 = "https://core.telegram.org/getDcV6"
+
+    global TG_DATACENTERS_V4
+    global TG_DATACENTERS_V6
+
+    while True:
+        try:
+            headers, body = await make_https_req(DC_INFO_ADDR_V4)
+            addrs = re.findall(rb"(?:\d{1,3}\.){3}\d{1,3}", body)
+            if addrs:
+                TG_DATACENTERS_V4 = [a.decode() for a in addrs]
+        except Exception as E:
+            print_err("Error updating datacenter IPv4 list:", E)
+
+        try:
+            headers, body = await make_https_req(DC_INFO_ADDR_V6)
+            addrs = [a.decode() for a in re.findall(rb"[0-9a-fA-F:]+", body) if b":" in a]
+            if addrs:
+                TG_DATACENTERS_V6 = addrs
+        except Exception as E:
+            print_err("Error updating datacenter IPv6 list:", E)
+
+        await asyncio.sleep(config.DC_INFO_UPDATE_PERIOD)
+
+
 async def update_middle_proxy_info():
     async def get_new_proxies(url):
         PROXY_REGEXP = re.compile(r"proxy_for\s+(-?\d+)\s+(.+):(\d+)\s*;")
@@ -2306,6 +2336,9 @@ def create_utilitary_tasks(loop):
 
     stats_printer_task = asyncio.Task(stats_printer(), loop=loop)
     tasks.append(stats_printer_task)
+
+    dc_info_updater_task = asyncio.Task(update_datacenter_info(), loop=loop)
+    tasks.append(dc_info_updater_task)
 
     if config.USE_MIDDLE_PROXY:
         middle_proxy_updater_task = asyncio.Task(update_middle_proxy_info(), loop=loop)


### PR DESCRIPTION
## Summary
- periodically update Telegram datacenter addresses
- expose `DC_INFO_UPDATE_PERIOD` in defaults and document it in `config.py`
- run the updater alongside other utilitary tasks
- mention automatic DC refresh in README

## Testing
- `python3 -m py_compile mtprotoproxy.py config.py`

------
https://chatgpt.com/codex/tasks/task_b_685383ceaf088333b89d4f63386da86d