### PR TITLE
Improve connection reliability via DC failover

### DIFF
--- a/mtprotoproxy.py
+++ b/mtprotoproxy.py
@@ -23,31 +23,41 @@ import traceback
 
 TG_DATACENTER_PORT = 443
 
-TG_DATACENTERS_V4 = [
-    "149.154.175.50", "149.154.167.51", "149.154.175.100",
-    "149.154.167.91", "149.154.171.5"
-]
+TG_DATACENTERS_V4 = ["149.154.175.50", "149.154.167.51", "149.154.175.100", "149.154.167.91", "149.154.171.5"]
 
 TG_DATACENTERS_V6 = [
-    "2001:b28:f23d:f001::a", "2001:67c:04e8:f002::a", "2001:b28:f23d:f003::a",
-    "2001:67c:04e8:f004::a", "2001:b28:f23f:f005::a"
+    "2001:b28:f23d:f001::a",
+    "2001:67c:04e8:f002::a",
+    "2001:b28:f23d:f003::a",
+    "2001:67c:04e8:f004::a",
+    "2001:b28:f23f:f005::a",
 ]
 
 # This list will be updated in the runtime
 TG_MIDDLE_PROXIES_V4 = {
-    1: [("149.154.175.50", 8888)], -1: [("149.154.175.50", 8888)],
-    2: [("149.154.161.144", 8888)], -2: [("149.154.161.144", 8888)],
-    3: [("149.154.175.100", 8888)], -3: [("149.154.175.100", 8888)],
-    4: [("91.108.4.136", 8888)], -4: [("149.154.165.109", 8888)],
-    5: [("91.108.56.181", 8888)], -5: [("91.108.56.181", 8888)]
+    1: [("149.154.175.50", 8888)],
+    -1: [("149.154.175.50", 8888)],
+    2: [("149.154.161.144", 8888)],
+    -2: [("149.154.161.144", 8888)],
+    3: [("149.154.175.100", 8888)],
+    -3: [("149.154.175.100", 8888)],
+    4: [("91.108.4.136", 8888)],
+    -4: [("149.154.165.109", 8888)],
+    5: [("91.108.56.181", 8888)],
+    -5: [("91.108.56.181", 8888)],
 }
 
 TG_MIDDLE_PROXIES_V6 = {
-    1: [("2001:b28:f23d:f001::d", 8888)], -1: [("2001:b28:f23d:f001::d", 8888)],
-    2: [("2001:67c:04e8:f002::d", 80)], -2: [("2001:67c:04e8:f002::d", 80)],
-    3: [("2001:b28:f23d:f003::d", 8888)], -3: [("2001:b28:f23d:f003::d", 8888)],
-    4: [("2001:67c:04e8:f004::d", 8888)], -4: [("2001:67c:04e8:f004::d", 8888)],
-    5: [("2001:b28:f23f:f005::d", 8888)], -5: [("2001:67c:04e8:f004::d", 8888)]
+    1: [("2001:b28:f23d:f001::d", 8888)],
+    -1: [("2001:b28:f23d:f001::d", 8888)],
+    2: [("2001:67c:04e8:f002::d", 80)],
+    -2: [("2001:67c:04e8:f002::d", 80)],
+    3: [("2001:b28:f23d:f003::d", 8888)],
+    -3: [("2001:b28:f23d:f003::d", 8888)],
+    4: [("2001:67c:04e8:f004::d", 8888)],
+    -4: [("2001:67c:04e8:f004::d", 8888)],
+    5: [("2001:b28:f23f:f005::d", 8888)],
+    -5: [("2001:67c:04e8:f004::d", 8888)],
 }
 
 # contains only proxies that responded successfully on the last check
@@ -55,10 +65,10 @@ ACTIVE_MIDDLE_PROXIES_V4 = {}
 ACTIVE_MIDDLE_PROXIES_V6 = {}
 
 PROXY_SECRET = bytes.fromhex(
-    "c4f9faca9678e6bb48ad6c7e2ce5c0d24430645d554addeb55419e034da62721" +
-    "d046eaab6e52ab14a95a443ecfb3463e79a05a66612adf9caeda8be9a80da698" +
-    "6fb0a6ff387af84d88ef3a6413713e5c3377f6e1a3d47d99f5e0c56eece8f05c" +
-    "54c490b079e31bef82ff0ee8f2b0a32756d249c5f21269816cb7061b265db212"
+    "c4f9faca9678e6bb48ad6c7e2ce5c0d24430645d554addeb55419e034da62721"
+    + "d046eaab6e52ab14a95a443ecfb3463e79a05a66612adf9caeda8be9a80da698"
+    + "6fb0a6ff387af84d88ef3a6413713e5c3377f6e1a3d47d99f5e0c56eece8f05c"
+    + "54c490b079e31bef82ff0ee8f2b0a32756d249c5f21269816cb7061b265db212"
 )
 
 SKIP_LEN = 8
@@ -80,7 +90,7 @@ CBC_PADDING = 16
 PADDING_FILLER = b"\x04\x00\x00\x00"
 
 MIN_MSG_LEN = 12
-MAX_MSG_LEN = 2 ** 24
+MAX_MSG_LEN = 2**24
 
 STAT_DURATION_BUCKETS = [0.1, 0.5, 1, 2, 5, 15, 60, 300, 600, 1800, 2**31 - 1]
 
@@ -127,7 +137,7 @@ def init_config():
     conf_dict = {k: v for k, v in conf_dict.items() if k.isupper()}
 
     conf_dict.setdefault("PORT", 3256)
-    conf_dict.setdefault("USERS", {"tg":  "00000000000000000000000000000000"})
+    conf_dict.setdefault("USERS", {"tg": "00000000000000000000000000000000"})
     conf_dict["AD_TAG"] = bytes.fromhex(conf_dict.get("AD_TAG", ""))
 
     for user, secret in conf_dict["USERS"].items():
@@ -242,19 +252,19 @@ def init_config():
     conf_dict.setdefault("STATS_PRINT_PERIOD", 600)
 
     # delay in seconds between middle proxy info updates
-    conf_dict.setdefault("PROXY_INFO_UPDATE_PERIOD", 24*60*60)
+    conf_dict.setdefault("PROXY_INFO_UPDATE_PERIOD", 24 * 60 * 60)
 
     # delay in seconds between active middle proxy checks
-    conf_dict.setdefault("ACTIVE_PROXY_REFRESH_PERIOD", 5*60)
+    conf_dict.setdefault("ACTIVE_PROXY_REFRESH_PERIOD", 5 * 60)
 
     # delay in seconds between datacenter info updates
-    conf_dict.setdefault("DC_INFO_UPDATE_PERIOD", 24*60*60)
+    conf_dict.setdefault("DC_INFO_UPDATE_PERIOD", 24 * 60 * 60)
 
     # delay in seconds between time getting, zero means disabled
-    conf_dict.setdefault("GET_TIME_PERIOD", 10*60)
+    conf_dict.setdefault("GET_TIME_PERIOD", 10 * 60)
 
     # delay in seconds between getting the length of certificate on the mask host
-    conf_dict.setdefault("GET_CERT_LEN_PERIOD", random.randrange(4*60*60, 6*60*60))
+    conf_dict.setdefault("GET_CERT_LEN_PERIOD", random.randrange(4 * 60 * 60, 6 * 60 * 60))
 
     # max socket buffer size to the client direction, the more the faster, but more RAM hungry
     # can be the tuple (low, users_margin, high) for the adaptive case. If no much users, use high
@@ -264,16 +274,16 @@ def init_config():
     conf_dict.setdefault("TO_TG_BUFSIZE", 65536)
 
     # keepalive period for clients in secs
-    conf_dict.setdefault("CLIENT_KEEPALIVE", 10*60)
+    conf_dict.setdefault("CLIENT_KEEPALIVE", 10 * 60)
 
     # drop client after this timeout if the handshake fail
     conf_dict.setdefault("CLIENT_HANDSHAKE_TIMEOUT", random.randrange(5, 15))
 
     # if client doesn't confirm data for this number of seconds, it is dropped
-    conf_dict.setdefault("CLIENT_ACK_TIMEOUT", 5*60)
+    conf_dict.setdefault("CLIENT_ACK_TIMEOUT", 5 * 60)
 
     # telegram servers connect timeout in seconds
-    conf_dict.setdefault("TG_CONNECT_TIMEOUT", 10)
+    conf_dict.setdefault("TG_CONNECT_TIMEOUT", 5)
 
     # the number of telegram connections kept in a pool
     conf_dict.setdefault("MAX_CONNS_IN_POOL", 64)
@@ -314,9 +324,15 @@ def apply_upstream_proxy_settings():
     # apply socks settings in place
     if config.SOCKS5_HOST and config.SOCKS5_PORT:
         import socks
+
         print_err("Socket-proxy mode activated, it is incompatible with advertising and uvloop")
-        socks.set_default_proxy(socks.PROXY_TYPE_SOCKS5, config.SOCKS5_HOST, config.SOCKS5_PORT,
-                                username=config.SOCKS5_USER, password=config.SOCKS5_PASS)
+        socks.set_default_proxy(
+            socks.PROXY_TYPE_SOCKS5,
+            config.SOCKS5_HOST,
+            config.SOCKS5_PORT,
+            username=config.SOCKS5_USER,
+            password=config.SOCKS5_PASS,
+        )
         if not hasattr(socket, "origsocket"):
             socket.origsocket = socket.socket
             socket.socket = socks.socksocket
@@ -330,7 +346,7 @@ def try_use_cryptography_module():
     from cryptography.hazmat.backends import default_backend
 
     class CryptographyEncryptorAdapter:
-        __slots__ = ('encryptor', 'decryptor')
+        __slots__ = ("encryptor", "decryptor")
 
         def __init__(self, cipher):
             self.encryptor = cipher.encryptor()
@@ -376,7 +392,7 @@ def use_slow_bundled_cryptography_module():
     print(msg, flush=True, file=sys.stderr)
 
     class BundledEncryptorAdapter:
-        __slots__ = ('mode', )
+        __slots__ = ("mode",)
 
         def __init__(self, mode):
             self.mode = mode
@@ -396,6 +412,7 @@ def use_slow_bundled_cryptography_module():
     def create_aes_cbc(key, iv):
         mode = pyaes.AESModeOfOperationCBC(key, iv)
         return BundledEncryptorAdapter(mode)
+
     return create_aes_ctr, create_aes_cbc
 
 
@@ -480,13 +497,13 @@ class MyRandom(random.Random):
 
     def getrandbits(self, k):
         numbytes = (k + 7) // 8
-        return int.from_bytes(self.getrandbytes(numbytes), 'big') >> (numbytes * 8 - k)
+        return int.from_bytes(self.getrandbytes(numbytes), "big") >> (numbytes * 8 - k)
 
     def getrandbytes(self, n):
         CHUNK_SIZE = 512
 
         while n > len(self.buffer):
-            data = int.to_bytes(super().getrandbits(CHUNK_SIZE*8), CHUNK_SIZE, "big")
+            data = int.to_bytes(super().getrandbits(CHUNK_SIZE * 8), CHUNK_SIZE, "big")
             self.buffer += self.encryptor.encrypt(data)
 
         result = self.buffer[:n]
@@ -511,8 +528,9 @@ class TgConnectionPool:
         set_bufsizes(writer_tgt.get_extra_info("socket"), get_to_clt_bufsize(), get_to_tg_bufsize())
 
         if init_func:
-            return await asyncio.wait_for(init_func(host, port, reader_tgt, writer_tgt),
-                                          timeout=config.TG_CONNECT_TIMEOUT)
+            return await asyncio.wait_for(
+                init_func(host, port, reader_tgt, writer_tgt), timeout=config.TG_CONNECT_TIMEOUT
+            )
         return reader_tgt, writer_tgt
 
     def register_host_port(self, host, port, init_func):
@@ -552,7 +570,7 @@ tg_connection_pool = TgConnectionPool()
 
 
 class LayeredStreamReaderBase:
-    __slots__ = ("upstream", )
+    __slots__ = ("upstream",)
 
     def __init__(self, upstream):
         self.upstream = upstream
@@ -565,7 +583,7 @@ class LayeredStreamReaderBase:
 
 
 class LayeredStreamWriterBase:
-    __slots__ = ("upstream", )
+    __slots__ = ("upstream",)
 
     def __init__(self, upstream):
         self.upstream = upstream
@@ -594,7 +612,7 @@ class LayeredStreamWriterBase:
 
 
 class FakeTLSStreamReader(LayeredStreamReaderBase):
-    __slots__ = ('buf', )
+    __slots__ = ("buf",)
 
     def __init__(self, upstream):
         self.upstream = upstream
@@ -645,14 +663,14 @@ class FakeTLSStreamWriter(LayeredStreamWriterBase):
     def write(self, data, extra={}):
         MAX_CHUNK_SIZE = 16384 + 24
         for start in range(0, len(data), MAX_CHUNK_SIZE):
-            end = min(start+MAX_CHUNK_SIZE, len(data))
-            self.upstream.write(b"\x17\x03\x03" + int.to_bytes(end-start, 2, "big"))
-            self.upstream.write(data[start: end])
+            end = min(start + MAX_CHUNK_SIZE, len(data))
+            self.upstream.write(b"\x17\x03\x03" + int.to_bytes(end - start, 2, "big"))
+            self.upstream.write(data[start:end])
         return len(data)
 
 
 class CryptoWrappedStreamReader(LayeredStreamReaderBase):
-    __slots__ = ('decryptor', 'block_size', 'buf')
+    __slots__ = ("decryptor", "block_size", "buf")
 
     def __init__(self, upstream, decryptor, block_size=1):
         self.upstream = upstream
@@ -690,7 +708,7 @@ class CryptoWrappedStreamReader(LayeredStreamReaderBase):
 
 
 class CryptoWrappedStreamWriter(LayeredStreamWriterBase):
-    __slots__ = ('encryptor', 'block_size')
+    __slots__ = ("encryptor", "block_size")
 
     def __init__(self, upstream, encryptor, block_size=1):
         self.upstream = upstream
@@ -699,15 +717,14 @@ class CryptoWrappedStreamWriter(LayeredStreamWriterBase):
 
     def write(self, data, extra={}):
         if len(data) % self.block_size != 0:
-            print_err("BUG: writing %d bytes not aligned to block size %d" % (
-                      len(data), self.block_size))
+            print_err("BUG: writing %d bytes not aligned to block size %d" % (len(data), self.block_size))
             return 0
         q = self.encryptor.encrypt(data)
         return self.upstream.write(q)
 
 
 class MTProtoFrameStreamReader(LayeredStreamReaderBase):
-    __slots__ = ('seq_no', )
+    __slots__ = ("seq_no",)
 
     def __init__(self, upstream, seq_no=0):
         self.upstream = upstream
@@ -721,7 +738,7 @@ class MTProtoFrameStreamReader(LayeredStreamReaderBase):
             msg_len_bytes = await self.upstream.readexactly(4)
             msg_len = int.from_bytes(msg_len_bytes, "little")
 
-        len_is_bad = (msg_len % len(PADDING_FILLER) != 0)
+        len_is_bad = msg_len % len(PADDING_FILLER) != 0
         if not MIN_MSG_LEN <= msg_len <= MAX_MSG_LEN or len_is_bad:
             print_err("msg_len is bad, closing connection", msg_len)
             return b""
@@ -745,7 +762,7 @@ class MTProtoFrameStreamReader(LayeredStreamReaderBase):
 
 
 class MTProtoFrameStreamWriter(LayeredStreamWriterBase):
-    __slots__ = ('seq_no', )
+    __slots__ = ("seq_no",)
 
     def __init__(self, upstream, seq_no=0):
         self.upstream = upstream
@@ -777,7 +794,7 @@ class MTProtoCompactFrameStreamReader(LayeredStreamReaderBase):
             extra["QUICKACK_FLAG"] = True
             msg_len -= 0x80
 
-        if msg_len == 0x7f:
+        if msg_len == 0x7F:
             msg_len_bytes = await self.upstream.readexactly(3)
             msg_len = int.from_bytes(msg_len_bytes, "little")
 
@@ -792,8 +809,8 @@ class MTProtoCompactFrameStreamWriter(LayeredStreamWriterBase):
     __slots__ = ()
 
     def write(self, data, extra={}):
-        SMALL_PKT_BORDER = 0x7f
-        LARGE_PKT_BORGER = 256 ** 3
+        SMALL_PKT_BORDER = 0x7F
+        LARGE_PKT_BORGER = 256**3
 
         if len(data) % 4 != 0:
             print_err("BUG: MTProtoFrameStreamWriter attempted to send msg with len", len(data))
@@ -807,7 +824,7 @@ class MTProtoCompactFrameStreamWriter(LayeredStreamWriterBase):
         if len_div_four < SMALL_PKT_BORDER:
             return self.upstream.write(bytes([len_div_four]) + data)
         elif len_div_four < LARGE_PKT_BORGER:
-            return self.upstream.write(b'\x7f' + int.to_bytes(len_div_four, 3, 'little') + data)
+            return self.upstream.write(b"\x7f" + int.to_bytes(len_div_four, 3, "little") + data)
         else:
             print_err("Attempted to send too large pkt len =", len(data))
             return 0
@@ -836,7 +853,7 @@ class MTProtoIntermediateFrameStreamWriter(LayeredStreamWriterBase):
         if extra.get("SIMPLE_ACK"):
             return self.upstream.write(data)
         else:
-            return self.upstream.write(int.to_bytes(len(data), 4, 'little') + data)
+            return self.upstream.write(int.to_bytes(len(data), 4, "little") + data)
 
 
 class MTProtoSecureIntermediateFrameStreamReader(LayeredStreamReaderBase):
@@ -871,7 +888,7 @@ class MTProtoSecureIntermediateFrameStreamWriter(LayeredStreamWriterBase):
         else:
             padding_len = myrandom.randrange(MAX_PADDING_LEN)
             padding = myrandom.getrandbytes(padding_len)
-            padded_data_len_bytes = int.to_bytes(len(data) + padding_len, 4, 'little')
+            padded_data_len_bytes = int.to_bytes(len(data) + padding_len, 4, "little")
             return self.upstream.write(padded_data_len_bytes + data + padding)
 
 
@@ -882,7 +899,7 @@ class ProxyReqStreamReader(LayeredStreamReaderBase):
         RPC_PROXY_ANS = b"\x0d\xda\x03\x44"
         RPC_CLOSE_EXT = b"\xa2\x34\xb6\x5e"
         RPC_SIMPLE_ACK = b"\x9b\x40\xac\x3b"
-        RPC_UNKNOWN = b'\xdf\xa2\x30\x57'
+        RPC_UNKNOWN = b"\xdf\xa2\x30\x57"
 
         data = await self.upstream.read(1)
 
@@ -909,7 +926,7 @@ class ProxyReqStreamReader(LayeredStreamReaderBase):
 
 
 class ProxyReqStreamWriter(LayeredStreamWriterBase):
-    __slots__ = ('remote_ip_port', 'our_ip_port', 'out_conn_id', 'proto_tag')
+    __slots__ = ("remote_ip_port", "our_ip_port", "out_conn_id", "proto_tag")
 
     def __init__(self, upstream, cl_ip, cl_port, my_ip, my_port, proto_tag):
         self.upstream = upstream
@@ -993,7 +1010,7 @@ def set_keepalive(sock, interval=40, attempts=5):
 
 def set_ack_timeout(sock, timeout):
     if hasattr(socket, "TCP_USER_TIMEOUT"):
-        try_setsockopt(sock, socket.IPPROTO_TCP, socket.TCP_USER_TIMEOUT, timeout*1000)
+        try_setsockopt(sock, socket.IPPROTO_TCP, socket.TCP_USER_TIMEOUT, timeout * 1000)
 
 
 def set_bufsizes(sock, recv_buf, send_buf):
@@ -1011,7 +1028,7 @@ def gen_x25519_public_key():
     # generates some number which has square root by modulo P
     P = 2**255 - 19
     n = myrandom.randrange(P)
-    return int.to_bytes((n*n) % P, length=32, byteorder="little")
+    return int.to_bytes((n * n) % P, length=32, byteorder="little")
 
 
 async def connect_reader_to_writer(reader, writer):
@@ -1077,7 +1094,7 @@ async def handle_bad_client(reader_clt, writer_clt, handshake):
         # if the server closed the connection with RST or FIN-RST, copy them to the client
         if not writer_srv.transport.is_closing():
             # workaround for uvloop, it doesn't fire exceptions on write_eof
-            sock = writer_srv.get_extra_info('socket')
+            sock = writer_srv.get_extra_info("socket")
             raw_sock = socket.socket(sock.family, sock.type, sock.proto, sock.fileno())
             try:
                 raw_sock.shutdown(socket.SHUT_WR)
@@ -1122,23 +1139,23 @@ async def handle_fake_tls_handshake(handshake, reader, writer, peer):
     tls_extensions = b"\x00\x2e" + b"\x00\x33\x00\x24" + b"\x00\x1d\x00\x20"
     tls_extensions += gen_x25519_public_key() + b"\x00\x2b\x00\x02\x03\x04"
 
-    digest = handshake[DIGEST_POS:DIGEST_POS+DIGEST_LEN]
+    digest = handshake[DIGEST_POS : DIGEST_POS + DIGEST_LEN]
 
     if digest[:DIGEST_HALFLEN] in used_handshakes:
         last_clients_with_same_handshake[peer[0]] += 1
         return False
 
     sess_id_len = handshake[SESSION_ID_LEN_POS]
-    sess_id = handshake[SESSION_ID_POS:SESSION_ID_POS+sess_id_len]
+    sess_id = handshake[SESSION_ID_POS : SESSION_ID_POS + sess_id_len]
 
     for user in config.USERS:
         secret = bytes.fromhex(config.USERS[user])
 
-        msg = handshake[:DIGEST_POS] + b"\x00"*DIGEST_LEN + handshake[DIGEST_POS+DIGEST_LEN:]
+        msg = handshake[:DIGEST_POS] + b"\x00" * DIGEST_LEN + handshake[DIGEST_POS + DIGEST_LEN :]
         computed_digest = hmac.new(secret, msg, digestmod=hashlib.sha256).digest()
 
         xored_digest = bytes(digest[i] ^ computed_digest[i] for i in range(DIGEST_LEN))
-        digest_good = xored_digest.startswith(b"\x00" * (DIGEST_LEN-4))
+        digest_good = xored_digest.startswith(b"\x00" * (DIGEST_LEN - 4))
 
         if not digest_good:
             continue
@@ -1147,7 +1164,7 @@ async def handle_fake_tls_handshake(handshake, reader, writer, peer):
         client_time_is_ok = TIME_SKEW_MIN < time.time() - timestamp < TIME_SKEW_MAX
 
         # some clients fail to read unix time and send the time since boot instead
-        client_time_is_small = timestamp < 60*60*24*1000
+        client_time_is_small = timestamp < 60 * 60 * 24 * 1000
         accept_bad_time = config.IGNORE_TIME_SKEW or is_time_skewed or client_time_is_small
 
         if not client_time_is_ok and not accept_bad_time:
@@ -1156,7 +1173,7 @@ async def handle_fake_tls_handshake(handshake, reader, writer, peer):
 
         http_data = myrandom.getrandbytes(fake_cert_len)
 
-        srv_hello = TLS_VERS + b"\x00"*DIGEST_LEN + bytes([sess_id_len]) + sess_id
+        srv_hello = TLS_VERS + b"\x00" * DIGEST_LEN + bytes([sess_id_len]) + sess_id
         srv_hello += TLS_CIPHERSUITE + b"\x00" + tls_extensions
 
         hello_pkt = b"\x16" + TLS_VERS + int.to_bytes(len(srv_hello) + 4, 2, "big")
@@ -1164,8 +1181,8 @@ async def handle_fake_tls_handshake(handshake, reader, writer, peer):
         hello_pkt += TLS_CHANGE_CIPHER + TLS_APP_HTTP2_HDR
         hello_pkt += int.to_bytes(len(http_data), 2, "big") + http_data
 
-        computed_digest = hmac.new(secret, msg=digest+hello_pkt, digestmod=hashlib.sha256).digest()
-        hello_pkt = hello_pkt[:DIGEST_POS] + computed_digest + hello_pkt[DIGEST_POS+DIGEST_LEN:]
+        computed_digest = hmac.new(secret, msg=digest + hello_pkt, digestmod=hashlib.sha256).digest()
+        hello_pkt = hello_pkt[:DIGEST_POS] + computed_digest + hello_pkt[DIGEST_POS + DIGEST_LEN :]
 
         writer.write(hello_pkt)
         await writer.drain()
@@ -1209,8 +1226,8 @@ async def handle_proxy_protocol(reader, peer=None):
         _, proxy_fam, *proxy_addr = header[:-2].split(b" ")
         if proxy_fam in (PROXY_TCP4, PROXY_TCP6):
             if len(proxy_addr) == 4:
-                src_addr = proxy_addr[0].decode('ascii')
-                src_port = int(proxy_addr[2].decode('ascii'))
+                src_addr = proxy_addr[0].decode("ascii")
+                src_port = int(proxy_addr[2].decode("ascii"))
                 return (src_addr, src_port)
         elif proxy_fam == PROXY_UNKNOWN:
             return peer
@@ -1220,19 +1237,19 @@ async def handle_proxy_protocol(reader, peer=None):
     if header.startswith(PROXY2_SIGNATURE):
         # proxy header v2
         proxy_ver = header[12]
-        if proxy_ver & 0xf0 != 0x20:
+        if proxy_ver & 0xF0 != 0x20:
             return False
         proxy_len = int.from_bytes(header[14:16], "big")
         proxy_addr = await reader.readexactly(proxy_len)
         if proxy_ver == 0x21:
             proxy_fam = header[13] >> 4
             if proxy_fam == PROXY2_AF_INET:
-                if proxy_len >= (4 + 2)*2:
+                if proxy_len >= (4 + 2) * 2:
                     src_addr = socket.inet_ntop(socket.AF_INET, proxy_addr[:4])
                     src_port = int.from_bytes(proxy_addr[8:10], "big")
                     return (src_addr, src_port)
             elif proxy_fam == PROXY2_AF_INET6:
-                if proxy_len >= (16 + 2)*2:
+                if proxy_len >= (16 + 2) * 2:
                     src_addr = socket.inet_ntop(socket.AF_INET6, proxy_addr[:16])
                     src_port = int.from_bytes(proxy_addr[32:34], "big")
                     return (src_addr, src_port)
@@ -1290,9 +1307,9 @@ async def handle_handshake(reader, writer):
             return False
         handshake += await reader.readexactly(HANDSHAKE_LEN - len(handshake))
 
-    dec_prekey_and_iv = handshake[SKIP_LEN:SKIP_LEN+PREKEY_LEN+IV_LEN]
+    dec_prekey_and_iv = handshake[SKIP_LEN : SKIP_LEN + PREKEY_LEN + IV_LEN]
     dec_prekey, dec_iv = dec_prekey_and_iv[:PREKEY_LEN], dec_prekey_and_iv[PREKEY_LEN:]
-    enc_prekey_and_iv = handshake[SKIP_LEN:SKIP_LEN+PREKEY_LEN+IV_LEN][::-1]
+    enc_prekey_and_iv = handshake[SKIP_LEN : SKIP_LEN + PREKEY_LEN + IV_LEN][::-1]
     enc_prekey, enc_iv = enc_prekey_and_iv[:PREKEY_LEN], enc_prekey_and_iv[PREKEY_LEN:]
 
     if dec_prekey_and_iv in used_handshakes:
@@ -1311,7 +1328,7 @@ async def handle_handshake(reader, writer):
 
         decrypted = decryptor.decrypt(handshake)
 
-        proto_tag = decrypted[PROTO_TAG_POS:PROTO_TAG_POS+4]
+        proto_tag = decrypted[PROTO_TAG_POS : PROTO_TAG_POS + 4]
         if proto_tag not in (PROTO_TAG_ABRIDGED, PROTO_TAG_INTERMEDIATE, PROTO_TAG_SECURE):
             continue
 
@@ -1324,7 +1341,7 @@ async def handle_handshake(reader, writer):
             if not config.MODES["classic"]:
                 continue
 
-        dc_idx = int.from_bytes(decrypted[DC_IDX_POS:DC_IDX_POS+2], "little", signed=True)
+        dc_idx = int.from_bytes(decrypted[DC_IDX_POS : DC_IDX_POS + 2], "little", signed=True)
 
         if config.REPLAY_CHECK_LEN > 0:
             while len(used_handshakes) >= config.REPLAY_CHECK_LEN:
@@ -1348,76 +1365,92 @@ async def handle_handshake(reader, writer):
 
 async def do_direct_handshake(proto_tag, dc_idx, dec_key_and_iv=None):
     RESERVED_NONCE_FIRST_CHARS = [b"\xef"]
-    RESERVED_NONCE_BEGININGS = [b"\x48\x45\x41\x44", b"\x50\x4F\x53\x54",
-                                b"\x47\x45\x54\x20", b"\xee\xee\xee\xee",
-                                b"\xdd\xdd\xdd\xdd", b"\x16\x03\x01\x02"]
+    RESERVED_NONCE_BEGININGS = [
+        b"\x48\x45\x41\x44",
+        b"\x50\x4f\x53\x54",
+        b"\x47\x45\x54\x20",
+        b"\xee\xee\xee\xee",
+        b"\xdd\xdd\xdd\xdd",
+        b"\x16\x03\x01\x02",
+    ]
     RESERVED_NONCE_CONTINUES = [b"\x00\x00\x00\x00"]
 
     global my_ip_info
     global tg_connection_pool
 
-    dc_idx = abs(dc_idx) - 1
+    start_idx = abs(dc_idx) - 1
 
     if my_ip_info["ipv6"] and (config.PREFER_IPV6 or not my_ip_info["ipv4"]):
-        if not 0 <= dc_idx < len(TG_DATACENTERS_V6):
-            return False
-        dc = TG_DATACENTERS_V6[dc_idx]
+        dc_list = TG_DATACENTERS_V6
     else:
-        if not 0 <= dc_idx < len(TG_DATACENTERS_V4):
-            return False
-        dc = TG_DATACENTERS_V4[dc_idx]
+        dc_list = TG_DATACENTERS_V4
 
-    try:
-        reader_tgt, writer_tgt = await tg_connection_pool.get_connection(dc, TG_DATACENTER_PORT)
-    except ConnectionRefusedError as E:
-        print_err("Got connection refused while trying to connect to", dc, TG_DATACENTER_PORT)
-        return False
-    except ConnectionAbortedError as E:
-        print_err("The Telegram server connection is bad: %d (%s %s) %s" % (dc_idx, addr, port, E))
-        return False
-    except (OSError, asyncio.TimeoutError) as E:
-        print_err("Unable to connect to", dc, TG_DATACENTER_PORT)
+    if not 0 <= start_idx < len(dc_list):
         return False
 
-    while True:
-        rnd = bytearray(myrandom.getrandbytes(HANDSHAKE_LEN))
-        if rnd[:1] in RESERVED_NONCE_FIRST_CHARS:
+    for i in range(len(dc_list)):
+        dc = dc_list[(start_idx + i) % len(dc_list)]
+        try:
+            reader_tgt, writer_tgt = await tg_connection_pool.get_connection(dc, TG_DATACENTER_PORT)
+        except (ConnectionRefusedError, ConnectionAbortedError, OSError, asyncio.TimeoutError):
+            print_err("Unable to connect to", dc, TG_DATACENTER_PORT)
             continue
-        if rnd[:4] in RESERVED_NONCE_BEGININGS:
+
+        try:
+            while True:
+                rnd = bytearray(myrandom.getrandbytes(HANDSHAKE_LEN))
+                if rnd[:1] in RESERVED_NONCE_FIRST_CHARS:
+                    continue
+                if rnd[:4] in RESERVED_NONCE_BEGININGS:
+                    continue
+                if rnd[4:8] in RESERVED_NONCE_CONTINUES:
+                    continue
+                break
+
+            rnd[PROTO_TAG_POS : PROTO_TAG_POS + 4] = proto_tag
+
+            if dec_key_and_iv:
+                rnd[SKIP_LEN : SKIP_LEN + KEY_LEN + IV_LEN] = dec_key_and_iv[::-1]
+
+            rnd = bytes(rnd)
+
+            dec_key_and_iv = rnd[SKIP_LEN : SKIP_LEN + KEY_LEN + IV_LEN][::-1]
+            dec_key, dec_iv = dec_key_and_iv[:KEY_LEN], dec_key_and_iv[KEY_LEN:]
+            decryptor = create_aes_ctr(key=dec_key, iv=int.from_bytes(dec_iv, "big"))
+
+            enc_key_and_iv = rnd[SKIP_LEN : SKIP_LEN + KEY_LEN + IV_LEN]
+            enc_key, enc_iv = enc_key_and_iv[:KEY_LEN], enc_key_and_iv[KEY_LEN:]
+            encryptor = create_aes_ctr(key=enc_key, iv=int.from_bytes(enc_iv, "big"))
+
+            rnd_enc = rnd[:PROTO_TAG_POS] + encryptor.encrypt(rnd)[PROTO_TAG_POS:]
+
+            writer_tgt.write(rnd_enc)
+            await writer_tgt.drain()
+
+            reader_tgt = CryptoWrappedStreamReader(reader_tgt, decryptor)
+            writer_tgt = CryptoWrappedStreamWriter(writer_tgt, encryptor)
+
+            return reader_tgt, writer_tgt
+        except Exception:
+            print_err("Handshake with", dc, "failed, trying next datacenter")
             continue
-        if rnd[4:8] in RESERVED_NONCE_CONTINUES:
-            continue
-        break
 
-    rnd[PROTO_TAG_POS:PROTO_TAG_POS+4] = proto_tag
-
-    if dec_key_and_iv:
-        rnd[SKIP_LEN:SKIP_LEN+KEY_LEN+IV_LEN] = dec_key_and_iv[::-1]
-
-    rnd = bytes(rnd)
-
-    dec_key_and_iv = rnd[SKIP_LEN:SKIP_LEN+KEY_LEN+IV_LEN][::-1]
-    dec_key, dec_iv = dec_key_and_iv[:KEY_LEN], dec_key_and_iv[KEY_LEN:]
-    decryptor = create_aes_ctr(key=dec_key, iv=int.from_bytes(dec_iv, "big"))
-
-    enc_key_and_iv = rnd[SKIP_LEN:SKIP_LEN+KEY_LEN+IV_LEN]
-    enc_key, enc_iv = enc_key_and_iv[:KEY_LEN], enc_key_and_iv[KEY_LEN:]
-    encryptor = create_aes_ctr(key=enc_key, iv=int.from_bytes(enc_iv, "big"))
-
-    rnd_enc = rnd[:PROTO_TAG_POS] + encryptor.encrypt(rnd)[PROTO_TAG_POS:]
-
-    writer_tgt.write(rnd_enc)
-    await writer_tgt.drain()
-
-    reader_tgt = CryptoWrappedStreamReader(reader_tgt, decryptor)
-    writer_tgt = CryptoWrappedStreamWriter(writer_tgt, encryptor)
-
-    return reader_tgt, writer_tgt
+    return False
 
 
-def get_middleproxy_aes_key_and_iv(nonce_srv, nonce_clt, clt_ts, srv_ip, clt_port, purpose,
-                                   clt_ip, srv_port, middleproxy_secret, clt_ipv6=None,
-                                   srv_ipv6=None):
+def get_middleproxy_aes_key_and_iv(
+    nonce_srv,
+    nonce_clt,
+    clt_ts,
+    srv_ip,
+    clt_port,
+    purpose,
+    clt_ip,
+    srv_port,
+    middleproxy_secret,
+    clt_ipv6=None,
+    srv_ipv6=None,
+):
     EMPTY_IP = b"\x00\x00\x00\x00"
 
     if not clt_ip or not srv_ip:
@@ -1442,7 +1475,7 @@ def get_middleproxy_aes_key_and_iv(nonce_srv, nonce_clt, clt_ts, srv_ip, clt_por
 
 
 async def middleproxy_handshake(host, port, reader_tgt, writer_tgt):
-    """ The most logic of middleproxy handshake, launched in pool """
+    """The most logic of middleproxy handshake, launched in pool"""
     START_SEQ_NO = -2
     NONCE_LEN = 16
 
@@ -1473,17 +1506,21 @@ async def middleproxy_handshake(host, port, reader_tgt, writer_tgt):
         raise ConnectionAbortedError("bad rpc answer length")
 
     rpc_type, rpc_key_selector, rpc_schema, rpc_crypto_ts, rpc_nonce = (
-        ans[:4], ans[4:8], ans[8:12], ans[12:16], ans[16:32]
+        ans[:4],
+        ans[4:8],
+        ans[8:12],
+        ans[12:16],
+        ans[16:32],
     )
 
     if rpc_type != RPC_NONCE or rpc_key_selector != key_selector or rpc_schema != CRYPTO_AES:
         raise ConnectionAbortedError("bad rpc answer")
 
     # get keys
-    tg_ip, tg_port = writer_tgt.upstream.get_extra_info('peername')[:2]
-    my_ip, my_port = writer_tgt.upstream.get_extra_info('sockname')[:2]
+    tg_ip, tg_port = writer_tgt.upstream.get_extra_info("peername")[:2]
+    my_ip, my_port = writer_tgt.upstream.get_extra_info("sockname")[:2]
 
-    use_ipv6_tg = (":" in tg_ip)
+    use_ipv6_tg = ":" in tg_ip
 
     if not use_ipv6_tg:
         if my_ip_info["ipv4"]:
@@ -1509,14 +1546,32 @@ async def middleproxy_handshake(host, port, reader_tgt, writer_tgt):
     my_port_bytes = int.to_bytes(my_port, 2, "little")
 
     enc_key, enc_iv = get_middleproxy_aes_key_and_iv(
-        nonce_srv=rpc_nonce, nonce_clt=nonce, clt_ts=crypto_ts, srv_ip=tg_ip_bytes,
-        clt_port=my_port_bytes, purpose=b"CLIENT", clt_ip=my_ip_bytes, srv_port=tg_port_bytes,
-        middleproxy_secret=PROXY_SECRET, clt_ipv6=my_ipv6_bytes, srv_ipv6=tg_ipv6_bytes)
+        nonce_srv=rpc_nonce,
+        nonce_clt=nonce,
+        clt_ts=crypto_ts,
+        srv_ip=tg_ip_bytes,
+        clt_port=my_port_bytes,
+        purpose=b"CLIENT",
+        clt_ip=my_ip_bytes,
+        srv_port=tg_port_bytes,
+        middleproxy_secret=PROXY_SECRET,
+        clt_ipv6=my_ipv6_bytes,
+        srv_ipv6=tg_ipv6_bytes,
+    )
 
     dec_key, dec_iv = get_middleproxy_aes_key_and_iv(
-        nonce_srv=rpc_nonce, nonce_clt=nonce, clt_ts=crypto_ts, srv_ip=tg_ip_bytes,
-        clt_port=my_port_bytes, purpose=b"SERVER", clt_ip=my_ip_bytes, srv_port=tg_port_bytes,
-        middleproxy_secret=PROXY_SECRET, clt_ipv6=my_ipv6_bytes, srv_ipv6=tg_ipv6_bytes)
+        nonce_srv=rpc_nonce,
+        nonce_clt=nonce,
+        clt_ts=crypto_ts,
+        srv_ip=tg_ip_bytes,
+        clt_port=my_port_bytes,
+        purpose=b"SERVER",
+        clt_ip=my_ip_bytes,
+        srv_port=tg_port_bytes,
+        middleproxy_secret=PROXY_SECRET,
+        clt_ipv6=my_ipv6_bytes,
+        srv_ipv6=tg_ipv6_bytes,
+    )
 
     encryptor = create_aes_cbc(key=enc_key, iv=enc_iv)
     decryptor = create_aes_cbc(key=dec_key, iv=dec_iv)
@@ -1538,7 +1593,11 @@ async def middleproxy_handshake(host, port, reader_tgt, writer_tgt):
         raise ConnectionAbortedError("bad rpc handshake answer length")
 
     handshake_type, handshake_flags, handshake_sender_pid, handshake_peer_pid = (
-        handshake_ans[:4], handshake_ans[4:8], handshake_ans[8:20], handshake_ans[20:32])
+        handshake_ans[:4],
+        handshake_ans[4:8],
+        handshake_ans[8:20],
+        handshake_ans[20:32],
+    )
     if handshake_type != RPC_HANDSHAKE or handshake_peer_pid != SENDER_PID:
         raise ConnectionAbortedError("bad rpc handshake answer")
 
@@ -1549,40 +1608,42 @@ async def do_middleproxy_handshake(proto_tag, dc_idx, cl_ip, cl_port):
     global my_ip_info
     global tg_connection_pool
 
-    use_ipv6_tg = (my_ip_info["ipv6"] and (config.PREFER_IPV6 or not my_ip_info["ipv4"]))
+    use_ipv6_tg = my_ip_info["ipv6"] and (config.PREFER_IPV6 or not my_ip_info["ipv4"])
 
     if use_ipv6_tg:
-        proxies = ACTIVE_MIDDLE_PROXIES_V6.get(dc_idx)
-        if not proxies:
-            proxies = TG_MIDDLE_PROXIES_V6.get(dc_idx)
-        if not proxies:
-            return False
-        addr, port = myrandom.choice(proxies)
+        proxies_active = ACTIVE_MIDDLE_PROXIES_V6
+        proxies_all = TG_MIDDLE_PROXIES_V6
+        total_dcs = len(TG_DATACENTERS_V6)
     else:
-        proxies = ACTIVE_MIDDLE_PROXIES_V4.get(dc_idx)
+        proxies_active = ACTIVE_MIDDLE_PROXIES_V4
+        proxies_all = TG_MIDDLE_PROXIES_V4
+        total_dcs = len(TG_DATACENTERS_V4)
+
+    start_idx = abs(dc_idx)
+    sign = -1 if dc_idx < 0 else 1
+
+    for shift in range(total_dcs):
+        idx = sign * (((start_idx - 1 + shift) % total_dcs) + 1)
+        proxies = proxies_active.get(idx)
         if not proxies:
-            proxies = TG_MIDDLE_PROXIES_V4.get(dc_idx)
+            proxies = proxies_all.get(idx)
         if not proxies:
-            return False
-        addr, port = myrandom.choice(proxies)
+            continue
 
-    try:
-        ret = await tg_connection_pool.get_connection(addr, port, middleproxy_handshake)
-        reader_tgt, writer_tgt, my_ip, my_port = ret
-    except ConnectionRefusedError as E:
-        print_err("The Telegram server %d (%s %s) is refusing connections" % (dc_idx, addr, port))
-        return False
-    except ConnectionAbortedError as E:
-        print_err("The Telegram server connection is bad: %d (%s %s) %s" % (dc_idx, addr, port, E))
-        return False
-    except (OSError, asyncio.TimeoutError) as E:
-        print_err("Unable to connect to the Telegram server %d (%s %s)" % (dc_idx, addr, port))
-        return False
+        for addr, port in proxies:
+            try:
+                ret = await tg_connection_pool.get_connection(addr, port, middleproxy_handshake)
+                reader_tgt, writer_tgt, my_ip, my_port = ret
+            except (ConnectionRefusedError, ConnectionAbortedError, OSError, asyncio.TimeoutError):
+                print_err("Unable to connect to the Telegram server %d (%s %s)" % (idx, addr, port))
+                continue
 
-    writer_tgt = ProxyReqStreamWriter(writer_tgt, cl_ip, cl_port, my_ip, my_port, proto_tag)
-    reader_tgt = ProxyReqStreamReader(reader_tgt)
+            writer_tgt = ProxyReqStreamWriter(writer_tgt, cl_ip, cl_port, my_ip, my_port, proto_tag)
+            reader_tgt = ProxyReqStreamReader(reader_tgt)
 
-    return reader_tgt, writer_tgt
+            return reader_tgt, writer_tgt
+
+    return False
 
 
 async def tg_connect_reader_to_writer(rd, wr, user, rd_buf_size, is_upstream):
@@ -1622,8 +1683,9 @@ async def handle_client(reader_clt, writer_clt):
     update_stats(connects_all=1)
 
     try:
-        clt_data = await asyncio.wait_for(handle_handshake(reader_clt, writer_clt),
-                                          timeout=config.CLIENT_HANDSHAKE_TIMEOUT)
+        clt_data = await asyncio.wait_for(
+            handle_handshake(reader_clt, writer_clt), timeout=config.CLIENT_HANDSHAKE_TIMEOUT
+        )
     except asyncio.TimeoutError:
         update_stats(handshake_timeouts=1)
         return
@@ -1636,7 +1698,7 @@ async def handle_client(reader_clt, writer_clt):
 
     update_user_stats(user, connects=1)
 
-    connect_directly = (not config.USE_MIDDLE_PROXY or disable_middle_proxy)
+    connect_directly = not config.USE_MIDDLE_PROXY or disable_middle_proxy
 
     if connect_directly:
         if config.FAST_MODE:
@@ -1652,6 +1714,7 @@ async def handle_client(reader_clt, writer_clt):
     reader_tg, writer_tg = tg_data
 
     if connect_directly and config.FAST_MODE:
+
         class FakeEncryptor:
             def encrypt(self, data):
                 return data
@@ -1676,29 +1739,21 @@ async def handle_client(reader_clt, writer_clt):
         else:
             return
 
-    tg_to_clt = tg_connect_reader_to_writer(reader_tg, writer_clt, user,
-                                            get_to_clt_bufsize(), False)
-    clt_to_tg = tg_connect_reader_to_writer(reader_clt, writer_tg,
-                                            user, get_to_tg_bufsize(), True)
+    tg_to_clt = tg_connect_reader_to_writer(reader_tg, writer_clt, user, get_to_clt_bufsize(), False)
+    clt_to_tg = tg_connect_reader_to_writer(reader_clt, writer_tg, user, get_to_tg_bufsize(), True)
     task_tg_to_clt = asyncio.ensure_future(tg_to_clt)
     task_clt_to_tg = asyncio.ensure_future(clt_to_tg)
 
     update_user_stats(user, curr_connects=1)
 
     tcp_limit_hit = (
-        user in config.USER_MAX_TCP_CONNS and
-        user_stats[user]["curr_connects"] > config.USER_MAX_TCP_CONNS[user]
+        user in config.USER_MAX_TCP_CONNS and user_stats[user]["curr_connects"] > config.USER_MAX_TCP_CONNS[user]
     )
 
-    user_expired = (
-        user in config.USER_EXPIRATIONS and
-        datetime.datetime.now() > config.USER_EXPIRATIONS[user]
-    )
+    user_expired = user in config.USER_EXPIRATIONS and datetime.datetime.now() > config.USER_EXPIRATIONS[user]
 
-    user_data_quota_hit = (
-        user in config.USER_DATA_QUOTA and
-        (user_stats[user]["octets_to_client"] +
-         user_stats[user]["octets_from_client"] > config.USER_DATA_QUOTA[user])
+    user_data_quota_hit = user in config.USER_DATA_QUOTA and (
+        user_stats[user]["octets_to_client"] + user_stats[user]["octets_from_client"] > config.USER_DATA_QUOTA[user]
     )
 
     if (not tcp_limit_hit) and (not user_expired) and (not user_data_quota_hit):
@@ -1743,7 +1798,7 @@ def make_metrics_pkt(metrics):
             for tag, tag_val in val.items():
                 if tag == "val":
                     continue
-                tag_val = tag_val.replace('"', r'\"')
+                tag_val = tag_val.replace('"', r"\"")
                 tags.append('%s="%s"' % (tag, tag_val))
             pkt_body_list.append("%s{%s} %s" % (name, ",".join(tags), val["val"]))
         else:
@@ -1780,25 +1835,22 @@ async def handle_metrics(reader, writer):
     try:
         metrics = []
         metrics.append(["uptime", "counter", "proxy uptime", time.time() - proxy_start_time])
-        metrics.append(["connects_bad", "counter", "connects with bad secret",
-                       stats["connects_bad"]])
+        metrics.append(["connects_bad", "counter", "connects with bad secret", stats["connects_bad"]])
         metrics.append(["connects_all", "counter", "incoming connects", stats["connects_all"]])
-        metrics.append(["handshake_timeouts", "counter", "number of timed out handshakes",
-                       stats["handshake_timeouts"]])
+        metrics.append(["handshake_timeouts", "counter", "number of timed out handshakes", stats["handshake_timeouts"]])
 
         if config.METRICS_EXPORT_LINKS:
             for link in proxy_links:
                 link_as_metric = link.copy()
                 link_as_metric["val"] = 1
-                metrics.append(["proxy_link_info", "counter",
-                                "the proxy link info", link_as_metric])
+                metrics.append(["proxy_link_info", "counter", "the proxy link info", link_as_metric])
 
         bucket_start = 0
         for bucket in STAT_DURATION_BUCKETS:
             bucket_end = bucket if bucket != STAT_DURATION_BUCKETS[-1] else "+Inf"
             metric = {
                 "bucket": "%s-%s" % (bucket_start, bucket_end),
-                "val": stats["connects_with_duration_le_%s" % str(bucket)]
+                "val": stats["connects_with_duration_le_%s" % str(bucket)],
             }
             metrics.append(["connects_by_duration", "counter", "connects by duration", metric])
             bucket_start = bucket_end
@@ -1806,10 +1858,8 @@ async def handle_metrics(reader, writer):
         user_metrics_desc = [
             ["user_connects", "counter", "user connects", "connects"],
             ["user_connects_curr", "gauge", "current user connects", "curr_connects"],
-            ["user_octets", "counter", "octets proxied for user",
-                "octets_from_client+octets_to_client"],
-            ["user_msgs", "counter", "msgs proxied for user",
-                "msgs_from_client+msgs_to_client"],
+            ["user_octets", "counter", "octets proxied for user", "octets_from_client+octets_to_client"],
+            ["user_msgs", "counter", "msgs proxied for user", "msgs_from_client+msgs_to_client"],
             ["user_octets_from", "counter", "octets proxied from user", "octets_from_client"],
             ["user_octets_to", "counter", "octets proxied to user", "octets_to_client"],
             ["user_msgs_from", "counter", "msgs proxied from user", "msgs_from_client"],
@@ -1848,10 +1898,16 @@ async def stats_printer():
 
         print("Stats for", time.strftime("%d.%m.%Y %H:%M:%S"))
         for user, stat in user_stats.items():
-            print("%s: %d connects (%d current), %.2f MB, %d msgs" % (
-                user, stat["connects"], stat["curr_connects"],
-                (stat["octets_from_client"] + stat["octets_to_client"]) / 1000000,
-                stat["msgs_from_client"] + stat["msgs_to_client"]))
+            print(
+                "%s: %d connects (%d current), %.2f MB, %d msgs"
+                % (
+                    user,
+                    stat["connects"],
+                    stat["curr_connects"],
+                    (stat["octets_from_client"] + stat["octets_to_client"]) / 1000000,
+                    stat["msgs_from_client"] + stat["msgs_to_client"],
+                )
+            )
         print(flush=True)
 
         if last_client_ips:
@@ -1876,12 +1932,11 @@ async def stats_printer():
 
 
 async def make_https_req(url, host="core.telegram.org"):
-    """ Make request, return resp body and headers. """
+    """Make request, return resp body and headers."""
     SSL_PORT = 443
     url_data = urllib.parse.urlparse(url)
 
-    HTTP_REQ_TEMPLATE = "\r\n".join(["GET %s HTTP/1.1", "Host: %s",
-                                     "Connection: close"]) + "\r\n\r\n"
+    HTTP_REQ_TEMPLATE = "\r\n".join(["GET %s HTTP/1.1", "Host: %s", "Connection: close"]) + "\r\n\r\n"
     reader, writer = await asyncio.open_connection(url_data.netloc, SSL_PORT, ssl=True)
     req = HTTP_REQ_TEMPLATE % (urllib.parse.quote(url_data.path), host)
     writer.write(req.encode("utf8"))
@@ -1949,8 +2004,9 @@ async def get_encrypted_cert(host, port, server_name):
         record4_type, record4 = await get_tls_record(reader)
         if record4_type != 23:
             return b""
-        msg = ("The MASK_HOST %s sent some TLS record before certificate record, this makes the " +
-               "proxy more detectable") % config.MASK_HOST
+        msg = (
+            "The MASK_HOST %s sent some TLS record before certificate record, this makes the " + "proxy more detectable"
+        ) % config.MASK_HOST
         print_err(msg)
 
         return record4
@@ -1975,25 +2031,19 @@ async def get_mask_host_cert_len():
             cert = await asyncio.wait_for(task, timeout=GET_CERT_TIMEOUT)
             if cert:
                 if len(cert) < MIN_CERT_LEN:
-                    msg = ("The MASK_HOST %s returned several TLS records, this is not supported" %
-                           config.MASK_HOST)
+                    msg = "The MASK_HOST %s returned several TLS records, this is not supported" % config.MASK_HOST
                     print_err(msg)
                 elif len(cert) != fake_cert_len:
                     fake_cert_len = len(cert)
-                    print_err("Got cert from the MASK_HOST %s, its length is %d" %
-                              (config.MASK_HOST, fake_cert_len))
+                    print_err("Got cert from the MASK_HOST %s, its length is %d" % (config.MASK_HOST, fake_cert_len))
             else:
-                print_err("The MASK_HOST %s is not TLS 1.3 host, this is not recommended" %
-                          config.MASK_HOST)
+                print_err("The MASK_HOST %s is not TLS 1.3 host, this is not recommended" % config.MASK_HOST)
         except ConnectionRefusedError:
-            print_err("The MASK_HOST %s is refusing connections, this is not recommended" %
-                      config.MASK_HOST)
+            print_err("The MASK_HOST %s is refusing connections, this is not recommended" % config.MASK_HOST)
         except (TimeoutError, asyncio.TimeoutError):
-            print_err("Got timeout while getting TLS handshake from MASK_HOST %s" %
-                      config.MASK_HOST)
+            print_err("Got timeout while getting TLS handshake from MASK_HOST %s" % config.MASK_HOST)
         except Exception as E:
-            print_err("Failed to connect to MASK_HOST %s: %s" % (
-                      config.MASK_HOST, E))
+            print_err("Failed to connect to MASK_HOST %s: %s" % (config.MASK_HOST, E))
 
         await asyncio.sleep(config.GET_CERT_LEN_PERIOD)
 
@@ -2013,10 +2063,10 @@ async def get_srv_time():
             for line in headers.split(b"\r\n"):
                 if not line.startswith(b"Date: "):
                     continue
-                line = line[len("Date: "):].decode()
+                line = line[len("Date: ") :].decode()
                 srv_time = datetime.datetime.strptime(line, "%a, %d %b %Y %H:%M:%S %Z")
                 now_time = datetime.datetime.utcnow()
-                is_time_skewed = (now_time-srv_time).total_seconds() > MAX_TIME_SKEW
+                is_time_skewed = (now_time - srv_time).total_seconds() > MAX_TIME_SKEW
                 if is_time_skewed and config.USE_MIDDLE_PROXY and not disable_middle_proxy:
                     print_err("Time skew detected, please set the clock")
                     print_err("Server time:", srv_time, "your time:", now_time)
@@ -2133,9 +2183,7 @@ async def update_active_proxies():
 
     async def is_proxy_alive(host, port):
         try:
-            reader, writer = await asyncio.wait_for(
-                asyncio.open_connection(host, port), timeout=5
-            )
+            reader, writer = await asyncio.wait_for(asyncio.open_connection(host, port), timeout=5)
             writer.close()
             if hasattr(writer, "wait_closed"):
                 await writer.wait_closed()
@@ -2230,14 +2278,14 @@ def print_tg_info():
         for ip in ip_addrs:
             if config.MODES["classic"]:
                 params = {"server": ip, "port": config.PORT, "secret": secret}
-                params_encodeded = urllib.parse.urlencode(params, safe=':')
+                params_encodeded = urllib.parse.urlencode(params, safe=":")
                 classic_link = "tg://proxy?{}".format(params_encodeded)
                 proxy_links.append({"user": user, "link": classic_link})
                 print("{}: {}".format(user, classic_link), flush=True)
 
             if config.MODES["secure"]:
                 params = {"server": ip, "port": config.PORT, "secret": "dd" + secret}
-                params_encodeded = urllib.parse.urlencode(params, safe=':')
+                params_encodeded = urllib.parse.urlencode(params, safe=":")
                 dd_link = "tg://proxy?{}".format(params_encodeded)
                 proxy_links.append({"user": user, "link": dd_link})
                 print("{}: {}".format(user, dd_link), flush=True)
@@ -2248,13 +2296,16 @@ def print_tg_info():
                 # tls_secret = bytes.fromhex("ee" + secret) + config.TLS_DOMAIN.encode()
                 # tls_secret_base64 = base64.urlsafe_b64encode(tls_secret)
                 params = {"server": ip, "port": config.PORT, "secret": tls_secret}
-                params_encodeded = urllib.parse.urlencode(params, safe=':')
+                params_encodeded = urllib.parse.urlencode(params, safe=":")
                 tls_link = "tg://proxy?{}".format(params_encodeded)
                 proxy_links.append({"user": user, "link": tls_link})
                 print("{}: {}".format(user, tls_link), flush=True)
 
-        if secret in ["00000000000000000000000000000000", "0123456789abcdef0123456789abcdef",
-                      "00000000000000000000000000000001"]:
+        if secret in [
+            "00000000000000000000000000000000",
+            "0123456789abcdef0123456789abcdef",
+            "00000000000000000000000000000001",
+        ]:
             msg = "The default secret {} is used, this is not recommended".format(secret)
             print(msg, flush=True)
             random_secret = "".join(myrandom.choice("0123456789abcdef") for i in range(32))
@@ -2274,6 +2325,7 @@ def print_tg_info():
 def setup_files_limit():
     try:
         import resource
+
         soft_fd_limit, hard_fd_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
         resource.setrlimit(resource.RLIMIT_NOFILE, (hard_fd_limit, hard_fd_limit))
     except (ValueError, OSError):
@@ -2288,14 +2340,17 @@ def setup_asyncio():
 
 
 def setup_signals():
-    if hasattr(signal, 'SIGUSR1'):
+    if hasattr(signal, "SIGUSR1"):
+
         def debug_signal(signum, frame):
             import pdb
+
             pdb.set_trace()
 
         signal.signal(signal.SIGUSR1, debug_signal)
 
-    if hasattr(signal, 'SIGUSR2'):
+    if hasattr(signal, "SIGUSR2"):
+
         def reload_signal(signum, frame):
             init_config()
             ensure_users_in_user_stats()
@@ -2312,6 +2367,7 @@ def try_setup_uvloop():
         return
     try:
         import uvloop
+
         asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
         print_err("Found uvloop, using it for optimal performance")
     except ImportError:
@@ -2337,12 +2393,11 @@ def loop_exception_handler(loop, context):
         if isinstance(exception, OSError):
             IGNORE_ERRNO = {
                 10038,  # operation on non-socket on Windows, likely because fd == -1
-                121,    # the semaphore timeout period has expired on Windows
+                121,  # the semaphore timeout period has expired on Windows
             }
 
             FORCE_CLOSE_ERRNO = {
-                113,    # no route to host
-
+                113,  # no route to host
             }
             if exception.errno in IGNORE_ERRNO:
                 return
@@ -2361,30 +2416,37 @@ def create_servers(loop):
     has_unix = hasattr(socket, "AF_UNIX")
 
     if config.LISTEN_ADDR_IPV4:
-        task = asyncio.start_server(handle_client_wrapper, config.LISTEN_ADDR_IPV4, config.PORT,
-                                    limit=get_to_tg_bufsize(), reuse_port=reuse_port)
+        task = asyncio.start_server(
+            handle_client_wrapper,
+            config.LISTEN_ADDR_IPV4,
+            config.PORT,
+            limit=get_to_tg_bufsize(),
+            reuse_port=reuse_port,
+        )
         servers.append(loop.run_until_complete(task))
 
     if config.LISTEN_ADDR_IPV6 and socket.has_ipv6:
-        task = asyncio.start_server(handle_client_wrapper, config.LISTEN_ADDR_IPV6, config.PORT,
-                                    limit=get_to_tg_bufsize(), reuse_port=reuse_port)
+        task = asyncio.start_server(
+            handle_client_wrapper,
+            config.LISTEN_ADDR_IPV6,
+            config.PORT,
+            limit=get_to_tg_bufsize(),
+            reuse_port=reuse_port,
+        )
         servers.append(loop.run_until_complete(task))
 
     if config.LISTEN_UNIX_SOCK and has_unix:
         remove_unix_socket(config.LISTEN_UNIX_SOCK)
-        task = asyncio.start_unix_server(handle_client_wrapper, config.LISTEN_UNIX_SOCK,
-                                         limit=get_to_tg_bufsize())
+        task = asyncio.start_unix_server(handle_client_wrapper, config.LISTEN_UNIX_SOCK, limit=get_to_tg_bufsize())
         servers.append(loop.run_until_complete(task))
         os.chmod(config.LISTEN_UNIX_SOCK, 0o666)
 
     if config.METRICS_PORT is not None:
         if config.METRICS_LISTEN_ADDR_IPV4:
-            task = asyncio.start_server(handle_metrics, config.METRICS_LISTEN_ADDR_IPV4,
-                                        config.METRICS_PORT)
+            task = asyncio.start_server(handle_metrics, config.METRICS_LISTEN_ADDR_IPV4, config.METRICS_PORT)
             servers.append(loop.run_until_complete(task))
         if config.METRICS_LISTEN_ADDR_IPV6 and socket.has_ipv6:
-            task = asyncio.start_server(handle_metrics, config.METRICS_LISTEN_ADDR_IPV6,
-                                        config.METRICS_PORT)
+            task = asyncio.start_server(handle_metrics, config.METRICS_LISTEN_ADDR_IPV6, config.METRICS_PORT)
             servers.append(loop.run_until_complete(task))
 
     return servers


### PR DESCRIPTION
## Summary
- retry Telegram datacenters when direct connection fails
- retry middle proxy datacenters when connection fails
- lower `TG_CONNECT_TIMEOUT` default to 5s

## Testing
- `black mtprotoproxy.py --line-length 120`
- `python3 -m py_compile mtprotoproxy.py`


------
https://chatgpt.com/codex/tasks/task_b_6853930f7d6c8333a0fa54a3424bc590