### PR TITLE
Support infinite TG connect timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,6 @@ The proxy can be launched:
   the pool. Reducing it (e.g. setting to `1`) avoids excessive reconnect
   attempts when there are few users.
 - active middle proxies check automatically (tweak with `ACTIVE_PROXY_REFRESH_PERIOD`)
+- set `TG_CONNECT_TIMEOUT` to `-1` to disable timeouts when establishing
+  Telegram connections.
 


### PR DESCRIPTION
## Summary
- allow `TG_CONNECT_TIMEOUT=-1` to disable connection timeouts
- document the new setting in README

## Testing
- `python3 -m py_compile mtprotoproxy.py config.py $(find pyaes -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68544552cf608333be3e2c2fa5843349